### PR TITLE
fix: get admin config from the correct location

### DIFF
--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -175,12 +175,12 @@ class Config {
         }).toList(growable: false) ??
         Language.values;
 
-    if (json['admin'] != null && json['admin'] is! bool) {
+    if (inno['admin'] != null && inno['admin'] is! bool) {
       CliLogger.exitError(
           "inno_bundle.admin attribute is invalid boolean value "
           "in pubspec.yaml");
     }
-    final bool admin = json['admin'] ?? true;
+    final bool admin = inno['admin'] ?? true;
 
     return Config(
       buildArgs: buildArgs,


### PR DESCRIPTION
Currently, the "admin" flag from the pubspec is ignored and always set to true because it isn't retrieved from the correct location. This PR fixes this by retrieving the "admin" flag from the inno entry of the config json.