### PR TITLE
chore: use windows application name instead project name

### DIFF
--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -16,6 +16,9 @@ class Config {
   /// The global pubspec name attribute, same name of the exe generated from flutter build.
   final String pubspecName;
 
+  /// Windows desktopapplication name.
+  final String windowsAppName;
+
   /// The name of the app after packaging.
   final String name;
 
@@ -66,6 +69,7 @@ class Config {
     required this.buildArgs,
     required this.id,
     required this.pubspecName,
+    required this.windowsAppName,
     required this.name,
     required this.description,
     required this.version,
@@ -79,7 +83,7 @@ class Config {
     required this.licenseFile,
     this.type = BuildType.debug,
     this.app = true,
-    this.installer = true, 
+    this.installer = true,
   });
 
   /// The name of the executable file that is created with flutter build.
@@ -121,11 +125,17 @@ class Config {
     }
     final String pubspecName = json['name'];
 
+    if (getWindowsAppName() is! String) {
+      CliLogger.exitError("windows app name is missing from windows/runner/main.cpp");
+    }
+
+    final String windowsAppName = getWindowsAppName()!;
+
     if (inno['name'] != null && !validFilenameRegex.hasMatch(inno['name'])) {
       CliLogger.exitError("inno_bundle.name from pubspec.yaml is not valid. "
           "`${inno['name']}` is not a valid file name.");
     }
-    final String name = inno['name'] ?? pubspecName;
+    final String name = inno['name'] ?? getWindowsAppName() ?? pubspecName;
 
     if ((appVersion ?? inno['version'] ?? json['version']) is! String) {
       CliLogger.exitError("version attribute is missing from pubspec.yaml.");
@@ -207,6 +217,7 @@ class Config {
       buildArgs: buildArgs,
       id: id,
       pubspecName: pubspecName,
+      windowsAppName: windowsAppName,
       name: name,
       description: description,
       version: version,

--- a/lib/utils/functions.dart
+++ b/lib/utils/functions.dart
@@ -73,3 +73,31 @@ String getHomeDir() {
   }
   return home;
 }
+
+/// Retrieves the application name from the main.cpp file.
+///
+/// Takes the path of the current directory, concatenates it with the
+/// subdirectories 'windows/runner', and reads the contents of 'main.cpp'
+/// file. It then searches for a line that matches the regex pattern
+/// 'Create(?:AndShow)?\(L"(.*?)"' and returns the first capturing group.
+String? getWindowsAppName() {
+  final String currentDir = Directory.current.path;
+  final String mainCppPath =
+      p.join(currentDir, 'windows', 'runner', 'main.cpp');
+  final File mainCppFile = File(mainCppPath);
+
+  if (!mainCppFile.existsSync()) {
+    return null;
+  }
+
+  final List<String> lines = mainCppFile.readAsLinesSync();
+  for (String line in lines) {
+    final RegExp regex = RegExp(r'Create(?:AndShow)?\(L"(.*?)"');
+    final Match? match = regex.firstMatch(line);
+    if (match != null) {
+      return match.group(1)?.trim();
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
**New `windowsAppName` Attribute:**
   - Added to the `Config` class for Windows application name retrieval.
   - Populated using the `getWindowsAppName` function.

**Error Handling:**
   - Added a check to ensure `windowsAppName` is retrieved correctly.
   - Suggestion: Expand error messages with possible solutions.