### PR TITLE
feat: add SignTool to the Inno Setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ All attributes should be under `inno_bundle` in `pubspec.yaml`.
   - `false`: Don't require elevated privileges during installation. App will
     install into user-specific folder.
 - `license_file`: A path relative to the project that points to a text license file, if not provided, `inno_bundle` will look up for `LICENSE` file in your project root folder. Otherwise, it is set to an empty string.
+- `sign_tool`: Specifies the name and parameters of the Sign Tool to be used to digitally sign the installer. The name of the sign tool can be added in Inno Setup's `Tools > Configure Sign Tools...`.
 
 <span id="attributes-more-1"><sup>1</sup></span> Only **.ico** images were
 tested.

--- a/example/demo_app/pubspec.yaml
+++ b/example/demo_app/pubspec.yaml
@@ -92,3 +92,4 @@ inno_bundle:
   license_file: assets/LICENSE.txt
   languages:
     - french
+  sign_tool: "signtool.exe sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a $p $f"

--- a/lib/builders/script_builder.dart
+++ b/lib/builders/script_builder.dart
@@ -28,6 +28,7 @@ class ScriptBuilder {
     final privileges = config.admin ? 'admin' : 'lowest';
     final installerName = '${camelCase(name)}-x86_64-$version-Installer';
     final licenseFile = config.licenseFile;
+    final signTool = config.signTool;
     var installerIcon = config.installerIcon;
     var uninstallIcon = "{app}\\${config.exeName}";
 
@@ -69,6 +70,7 @@ WizardStyle=modern
 ArchitecturesInstallIn64BitMode=x64
 DisableDirPage=auto
 DisableProgramGroupPage=auto
+${signTool.isNotEmpty ? 'SignTool=$signTool' : ''}
 \n''';
   }
 

--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -43,6 +43,9 @@ class Config {
   // The path to the text license file.
   final String licenseFile;
 
+  // The name or commmand to be used to digitally sign the installer.
+  final String signTool;
+
   /// The supported languages for the installer.
   final List<Language> languages;
 
@@ -77,6 +80,7 @@ class Config {
     required this.languages,
     required this.admin,
     required this.licenseFile,
+    required this.signTool,
     this.type = BuildType.debug,
     this.app = true,
     this.installer = true,
@@ -200,6 +204,8 @@ class Config {
     final licenseFile =
         File(licenseFilePath).existsSync() ? licenseFilePath : '';
 
+    final signTool = (inno['sign_tool'] ?? "") as String;
+
     return Config(
       buildArgs: buildArgs,
       id: id,
@@ -218,6 +224,7 @@ class Config {
       app: app,
       installer: installer,
       licenseFile: licenseFile,
+      signTool: signTool,
     );
   }
 


### PR DESCRIPTION
- Add `SignTool` by adding `sign_tool` under `inno_bundle` in the `pubspec.yaml` file
- If not specified/empty, the `SignTool` won't be added to the script, otherwise the script will become invalid.