### PR TITLE
feat: silent mode support and passing arguments to the executable.

### DIFF
--- a/lib/builders/script_builder.dart
+++ b/lib/builders/script_builder.dart
@@ -13,6 +13,7 @@
 /// - [_files]: Generates the `[Files]` section.
 /// - [_icons]: Generates the `[Icons]` section.
 /// - [_run]: Generates the `[Run]` section.
+/// - [_code]: Generates the `[Code]` section.
 ///
 /// The [build] method is the main method of this class, which combines all the sections and writes
 /// the complete ISS script to a file. It returns the generated script file.
@@ -20,8 +21,8 @@ library;
 
 import 'dart:io';
 
-import 'package:inno_bundle/models/config.dart';
 import 'package:inno_bundle/models/admin_mode.dart';
+import 'package:inno_bundle/models/config.dart';
 import 'package:inno_bundle/utils/cli_logger.dart';
 import 'package:inno_bundle/utils/constants.dart';
 import 'package:inno_bundle/utils/functions.dart';
@@ -169,9 +170,28 @@ Name: "{autodesktop}\\${config.name}"; Filename: "{app}\\${config.exeName}"; Tas
 
   /// Generates the `[Run]` section, specifying actions to perform after the installation is complete.
   String _run() {
+    String normalModeParameters = "";
+    String silentModeParameters = "";
+
+    if (config.runArgs != null) {
+      normalModeParameters = " Parameters: \"${config.runArgs?.join(" ")}\";";
+    }
+
+    String normalMode =
+        '''Filename: "{app}\\${config.exeName}";$normalModeParameters Description: "{cm:LaunchProgram,{#StringChange('${config.name}', '&', '&&')}}"; Flags: nowait postinstall skipifsilent; Check: not IsSilentInstall''';
+    String silentMode = "";
+
+    if (config.runIfSilentMode == true && config.runSilentArgs != null) {
+      silentModeParameters =
+          " Parameters: \"${config.runSilentArgs?.join(" ")}\";";
+      silentMode =
+          '''Filename: "{app}\\${config.exeName}";$silentModeParameters Description: "{cm:LaunchProgram,{#StringChange('${config.name}', '&', '&&')}}"; Flags: nowait postinstall; Check: IsSilentInstall''';
+    }
+
     return '''
 [Run]
-Filename: "{app}\\${config.exeName}"; Description: "{cm:LaunchProgram,{#StringChange('${config.name}', '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+$normalMode
+$silentMode
 \n''';
   }
 

--- a/lib/builders/script_builder.dart
+++ b/lib/builders/script_builder.dart
@@ -195,6 +195,29 @@ $silentMode
 \n''';
   }
 
+  /// Generates the `[Code]` section, allowing the inclusion of Pascal code to customize the behavior of the installer and define additional logic during the installation process.
+  String _code() {
+    String appendContent = "";
+
+    if (config.appendSectionCode != null) {
+      if (config.appendSectionCode!.startsWith("file:")) {
+        appendContent =
+            File(config.appendSectionCode!.replaceFirst("file:", ""))
+                .readAsStringSync();
+      } else {
+        appendContent = config.appendSectionCode!;
+      }
+    }
+
+    return '''
+[Code]
+function IsSilentInstall: Boolean;
+begin
+  Result := WizardSilent;
+end;
+\n$appendContent''';
+  }
+
   /// Generates the ISS script file and returns its path.
   Future<File> build() async {
     CliLogger.info("Generating ISS script...");
@@ -205,7 +228,8 @@ $silentMode
         _tasks() +
         _files() +
         _icons() +
-        _run();
+        _run() +
+        _code();
     final relScriptPath = p.joinAll([
       ...installerBuildDir,
       config.type.dirName,

--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -12,10 +12,11 @@
 library;
 
 import 'dart:io';
+
+import 'package:inno_bundle/models/admin_mode.dart';
 import 'package:inno_bundle/models/build_arch.dart';
 import 'package:inno_bundle/models/build_type.dart';
 import 'package:inno_bundle/models/language.dart';
-import 'package:inno_bundle/models/admin_mode.dart';
 import 'package:inno_bundle/models/sign_tool.dart';
 import 'package:inno_bundle/utils/cli_logger.dart';
 import 'package:inno_bundle/utils/constants.dart';
@@ -83,6 +84,18 @@ class Config {
   /// Arguments to be passed to flutter build.
   final String? buildArgs;
 
+  /// Run the executable if the installer is in silent mode.
+  final bool? runIfSilentMode;
+
+  /// Arguments to be passed to the executable after the installer finishes successfully.
+  final List<String>? runArgs;
+
+  /// Arguments to be passed to the executable after the installer successfully completes in silent mode.
+  final List<String>? runSilentArgs;
+
+  /// Content to be appended in the [Code] section.
+  final String? appendSectionCode;
+
   /// Creates a [Config] instance with default values.
   const Config({
     required this.buildArgs,
@@ -104,6 +117,10 @@ class Config {
     this.type = BuildType.debug,
     this.app = true,
     this.installer = true,
+    required this.runIfSilentMode,
+    required this.runArgs,
+    required this.runSilentArgs,
+    required this.appendSectionCode,
   });
 
   /// The name of the executable file that is created with flutter build.
@@ -250,6 +267,11 @@ class Config {
     }
     final arch = BuildArch.fromOption(inno['arch']);
 
+    final runIfSilentMode = (inno["run_if_silent_mode"] as bool?) ?? false;
+    final runArgs = (inno['run_args'] as List<String>?);
+    final runSilentArgs = (inno['run_silent_args'] as List<String>?);
+    final appendSectionCode = inno['append_section_code'] as String?;
+
     return Config(
       buildArgs: buildArgs,
       id: id,
@@ -270,6 +292,10 @@ class Config {
       licenseFile: licenseFile,
       signTool: signTool,
       arch: arch,
+      runIfSilentMode: runIfSilentMode,
+      runArgs: runArgs,
+      runSilentArgs: runSilentArgs,
+      appendSectionCode: appendSectionCode,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inno_bundle
 description: CLI tool for automating Windows installer creation using Inno Setup.
 maintainer: Hocine Abdellatif Houari
-version: 0.7.4
+version: 0.7.5
 homepage: https://github.com/hahouari/inno_bundle
 
 environment:


### PR DESCRIPTION
This MR resolves issue #9.

- Add support for running the executable in silent mode.
- Add support for passing arguments to the executable in both modes (normal and silent).
- Add support for appending content to the [Code] section via file or String.

Example definition in pubspec.yaml file:
![image](https://github.com/user-attachments/assets/f546e3a2-1993-4b3e-b0d3-f132f62a668a)
