### PR TITLE
feat: add an option to use custom config name inside pubspec.yaml file

### DIFF
--- a/bin/build.dart
+++ b/bin/build.dart
@@ -68,6 +68,11 @@ void main(List<String> arguments) async {
     ..addOption("sign-tool-name", help: "Override sign tool name")
     ..addOption("sign-tool-command", help: "Override sign tool command")
     ..addOption("sign-tool-params", help: "Override sign tool params")
+    ..addOption(
+      'config-name',
+      help: 'The config name to use inside pubspec.yaml\n'
+          'Defaults to "inno_bundle"',
+    )
     ..addFlag(
       'envs',
       defaultsTo: false,

--- a/lib/models/cli_config.dart
+++ b/lib/models/cli_config.dart
@@ -45,6 +45,10 @@ class CliConfig {
   /// Override sign tool params.
   final String? signToolParams;
 
+  /// The config name to use inside pubspec.yaml (defaults to inno_bundle).
+  /// Useful when using multiple configs in the same project.
+  final String configName;
+
   /// Creates a [CliConfig] instance with default values.
   const CliConfig({
     this.type = BuildType.debug,
@@ -59,6 +63,7 @@ class CliConfig {
     this.signToolName,
     this.signToolCommand,
     this.signToolParams,
+    this.configName = 'inno_bundle',
   });
 
   /// Creates a [CliConfig] instance from command-line arguments using [ArgResults].
@@ -76,6 +81,7 @@ class CliConfig {
       signToolName: args['sign-tool-name'],
       signToolCommand: args['sign-tool-command'],
       signToolParams: args['sign-tool-params'],
+      configName: args['config-name'],
     );
   }
 }

--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -135,18 +135,19 @@ class Config {
     required CliConfig cliConfig,
     required File pubspecFile,
   }) {
-    if (json['inno_bundle'] is! Map<String, dynamic>) {
-      CliLogger.exitError("inno_bundle section is missing from pubspec.yaml.");
+    final configName = cliConfig.configName;
+    if (json[configName] is! Map<String, dynamic>) {
+      CliLogger.exitError("$configName section is missing from pubspec.yaml.");
     }
-    final Map<String, dynamic> inno = json['inno_bundle'];
+    final Map<String, dynamic> inno = json[configName];
 
     if (inno['id'] is! String) {
       CliLogger.exitError(
-          "inno_bundle.id attribute is missing from pubspec.yaml. "
+          "$configName.id attribute is missing from pubspec.yaml. "
           "Run `dart run inno_bundle:guid` to generate a new one, "
           "then put it in your pubspec.yaml.");
     } else if (!Uuid.isValidUUID(fromString: inno['id'])) {
-      CliLogger.exitError("inno_bundle.id from pubspec.yaml is not valid. "
+      CliLogger.exitError("$configName.id from pubspec.yaml is not valid. "
           "Run `dart run inno_bundle:guid` to generate a new one, "
           "then put it in your pubspec.yaml.");
     }
@@ -158,7 +159,7 @@ class Config {
     final String pubspecName = json['name'];
 
     if (inno['name'] != null && !validFilenameRegex.hasMatch(inno['name'])) {
-      CliLogger.exitError("inno_bundle.name from pubspec.yaml is not valid. "
+      CliLogger.exitError("$configName.name from pubspec.yaml is not valid. "
           "`${inno['name']}` is not a valid file name.");
     }
     final String name = inno['name'] ?? pubspecName;
@@ -177,7 +178,7 @@ class Config {
     final String description = inno['description'] ?? json['description'];
 
     if ((inno['publisher'] ?? json['maintainer']) is! String) {
-      CliLogger.exitError("maintainer or inno_bundle.publisher attributes are "
+      CliLogger.exitError("maintainer or $configName.publisher attributes are "
           "missing from pubspec.yaml.");
     }
     final String publisher = inno['publisher'] ?? json['maintainer'];
@@ -187,7 +188,7 @@ class Config {
     final updatesUrl = (inno['updates_url'] as String?) ?? url;
 
     if (inno['installer_icon'] != null && inno['installer_icon'] is! String) {
-      CliLogger.exitError("inno_bundle.installer_icon attribute is invalid "
+      CliLogger.exitError("$configName.installer_icon attribute is invalid "
           "in pubspec.yaml.");
     }
     final installerIcon = inno['installer_icon'] != null
@@ -199,12 +200,12 @@ class Config {
     if (installerIcon != defaultInstallerIconPlaceholder &&
         !File(installerIcon).existsSync()) {
       CliLogger.exitError(
-          "inno_bundle.installer_icon attribute value is invalid, "
+          "$configName.installer_icon attribute value is invalid, "
           "`$installerIcon` file does not exist.");
     }
 
     if (inno['languages'] != null && inno['languages'] is! List) {
-      CliLogger.exitError("inno_bundle.languages attribute is invalid "
+      CliLogger.exitError("$configName.languages attribute is invalid "
           "in pubspec.yaml, only a list of strings is allowed.");
     }
     final languages = (inno['languages'] as List?)
@@ -222,13 +223,13 @@ class Config {
     if (inno['admin'] != null &&
         inno['admin'] is! bool &&
         inno['admin'] != "auto") {
-      CliLogger.exitError("inno_bundle.admin attribute is invalid value "
+      CliLogger.exitError("$configName.admin attribute is invalid value "
           "in pubspec.yaml");
     }
     final admin = AdminMode.fromOption(inno['admin'] ?? true);
 
     if (inno['license_file'] != null && inno['license_file'] is! String) {
-      CliLogger.exitError("inno_bundle.license_file attribute is invalid "
+      CliLogger.exitError("$configName.license_file attribute is invalid "
           "in pubspec.yaml.");
     }
 
@@ -262,13 +263,13 @@ class Config {
     if (inno['vc_redist'] != null &&
         inno['vc_redist'] is! bool &&
         inno['vc_redist'] != "download") {
-      CliLogger.exitError("inno_bundle.vc_redist attribute is invalid value "
+      CliLogger.exitError("$configName.vc_redist attribute is invalid value "
           "in pubspec.yaml");
     }
     final vcRedist = VcRedistMode.fromOption(inno['vc_redist'] ?? true);
 
     if (inno['dlls'] != null && inno['dlls'] is! List) {
-      CliLogger.exitError("inno_bundle.dlls attribute is invalid "
+      CliLogger.exitError("$configName.dlls attribute is invalid "
           "in pubspec.yaml, only a list of dll entries is allowed.");
     }
     final dlls = ((inno['dlls'] ?? []) as List)

--- a/lib/utils/functions.dart
+++ b/lib/utils/functions.dart
@@ -109,17 +109,18 @@ void generateEssentials(File pubspecFile, CliConfig cliConfig) {
   if (!cliConfig.generateAppId && !cliConfig.generatePublisher) return;
 
   final json = readPubspec(pubspecFile);
-  final inno = json['inno_bundle'] ?? {};
+  final configName = cliConfig.configName;
+  final inno = json[configName] ?? {};
 
   // if inno_bundle essentials are already present, do nothing
   if (inno['id'] != null || inno['publisher'] != null) return;
 
   final lines = pubspecFile.readAsLinesSync();
-  var innoInsertLine = lines.indexWhere((l) => l.startsWith("inno_bundle:"));
+  var innoInsertLine = lines.indexWhere((l) => l.startsWith("$configName:"));
 
   // if inno_bundle section is not found, add it at the end of the file
   if (innoInsertLine == -1) {
-    lines.add("inno_bundle:");
+    lines.add("$configName:");
     innoInsertLine = lines.length - 1;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inno_bundle
 description: CLI tool for automating Windows installer creation using Inno Setup.
 maintainer: Hocine Abdellatif Houari
-version: 0.9.0
+version: 0.10.0
 homepage: https://github.com/hahouari/inno_bundle
 
 environment:


### PR DESCRIPTION
Hey! 

I needed an option to use a different configuration for a white label app, so I added an option `config-name` to the CLI to be able to have the following inside `pubspec.yaml` file: 

```yaml
inno_bundle_first:
  id: <uuid_1>
  name: <an app name>
  languages:
    - english

inno_bundle_second:
  id: <uuid_2>
  name: <another app name>
  languages:
    - french

...
```

Let me know if you need more explanation on the use case! 