### PR TITLE
Added Skipbuild config

### DIFF
--- a/lib/builders/app_builder.dart
+++ b/lib/builders/app_builder.dart
@@ -51,6 +51,21 @@ class AppBuilder {
       }
     }
 
+    /// Checks if the build process should be skipped based on the configuration.
+    if (config.skipBuild) {
+      CliLogger.info("Skipping building app...");
+
+      /// Verifies if the build directory exists and is not empty.
+      if (buildDir.existsSync() && buildDir.listSync().isNotEmpty) {
+        /// Returns the build directory if it exists and is not empty.
+        return buildDir;
+      } else {
+        /// Logs an error message if the build directory does not exist or is empty.
+        CliLogger.error(
+            "Build directory does not exist or is empty.exiting now....");
+        exit(1);
+      }
+    }
     final process = await Process.start(
       "flutter",
       [

--- a/lib/builders/app_builder.dart
+++ b/lib/builders/app_builder.dart
@@ -53,7 +53,7 @@ class AppBuilder {
 
     /// Checks if the build process should be skipped based on the configuration.
     if (config.skipBuild) {
-      CliLogger.info("Skipping building app...");
+      CliLogger.warning("Skipping building app...");
 
       /// Verifies if the build directory exists and is not empty.
       if (buildDir.existsSync() && buildDir.listSync().isNotEmpty) {
@@ -62,7 +62,7 @@ class AppBuilder {
       } else {
         /// Logs an error message if the build directory does not exist or is empty.
         CliLogger.error(
-            "Build directory does not exist or is empty.exiting now....");
+            "Build directory does not exist or is empty.Please build again using build command.Exiting now....");
         exit(1);
       }
     }

--- a/lib/builders/script_builder.dart
+++ b/lib/builders/script_builder.dart
@@ -20,14 +20,15 @@ library;
 
 import 'dart:io';
 
-import 'package:inno_bundle/models/config.dart';
+import 'package:path/path.dart' as p;
+
 import 'package:inno_bundle/models/admin_mode.dart';
+import 'package:inno_bundle/models/config.dart';
 import 'package:inno_bundle/models/dll_entry.dart';
 import 'package:inno_bundle/models/vcredist_mode.dart';
 import 'package:inno_bundle/utils/cli_logger.dart';
 import 'package:inno_bundle/utils/constants.dart';
 import 'package:inno_bundle/utils/functions.dart';
-import 'package:path/path.dart' as p;
 
 /// A class responsible for generating the Inno Setup Script (ISS) file for the installer.
 class ScriptBuilder {
@@ -124,11 +125,11 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
       final filePath = appFile.absolute.path;
       if (FileSystemEntity.isDirectorySync(filePath)) {
         final fileName = p.basename(filePath);
-        section += "Source: \"$filePath\\*\"; DestDir: \"{app}\\$fileName\"; "
-            "Flags: ignoreversion recursesubdirs createallsubdirs\n";
+        section += 'Source: "$filePath\\*"; DestDir: "{app}\\$fileName"; '
+            'Flags: ignoreversion recursesubdirs createallsubdirs\n';
       } else {
-        section += "Source: \"$filePath\"; DestDir: \"{app}\"; "
-            "Flags: ignoreversion\n";
+        section += 'Source: "$filePath"; DestDir: "{app}"; '
+            'Flags: ignoreversion\n';
       }
     }
 
@@ -158,8 +159,25 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
       final dllPath = p.join(scriptDirPath, p.basename(file.path));
       final dllName = dll.name;
       file.copySync(dllPath);
-      section += "Source: \"$dllPath\"; DestDir: \"{app}\"; "
-          "DestName: \"$dllName\"; Flags: ignoreversion\n";
+      section += 'Source: "$dllPath"; DestDir: "{app}"; '
+          'DestName: "$dllName"; Flags: ignoreversion\n';
+    }
+
+    final files = config.files.toList();
+    for (final f in files) {
+      final file = File(f.absolutePath);
+      if (!file.existsSync()) {
+        // if the file is not required, skip it, otherwise exit with error.
+        if (!f.required) continue;
+        CliLogger.exitError("Required file ${file.path} does not exist.");
+      }
+
+      final fPath = p.join(scriptDirPath, p.basename(file.path));
+      final fName = f.name;
+      file.copySync(fPath);
+      final destDir = f.destinationDir == null ? "{app}" : "{app}\\${f.destinationDir}";
+      section += 'Source: "$fPath"; DestDir: "$destDir"; '
+          'DestName: "$fName"; Flags: ignoreversion\n';
     }
 
     return '$section\n';
@@ -224,15 +242,7 @@ end;
   /// Generates the ISS script file and returns its path.
   Future<File> build() async {
     CliLogger.info("Generating ISS script...");
-    final script = scriptHeader +
-        _setup() +
-        _installDelete() +
-        _languages() +
-        _tasks() +
-        _files() +
-        _icons() +
-        _run() +
-        _downloadVcRedist();
+    final script = scriptHeader + _setup() + _installDelete() + _languages() + _tasks() + _files() + _icons() + _run() + _downloadVcRedist();
     final relScriptPath = p.joinAll([
       ...installerBuildDir,
       config.type.dirName,

--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -96,9 +96,17 @@ class Config {
 
   /// List of dlls to be included in the installer.
   final List<DllEntry> dlls;
-  
+
   /// List of files to be included in the installer.
   final List<FileEntry> files;
+
+  /// Controls whether the app build process is skipped.
+  ///
+  /// If you're using a third-party build framework like Shorebird, set this to `true`
+  /// to bypass the default `flutter build windows` command.
+  ///
+  /// Note: This property is specifically intended for use with Shorebird or manual build.
+  final bool skipBuild;
 
   /// Creates a [Config] instance with default values.
   const Config({
@@ -125,6 +133,7 @@ class Config {
     this.type = BuildType.debug,
     this.app = true,
     this.installer = true,
+    this.skipBuild = false,
   });
 
   /// The name of the executable file that is created with flutter build.

--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -13,19 +13,21 @@ library;
 
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+import 'package:uuid/uuid.dart';
+
 import 'package:inno_bundle/models/admin_mode.dart';
 import 'package:inno_bundle/models/build_arch.dart';
 import 'package:inno_bundle/models/build_type.dart';
 import 'package:inno_bundle/models/cli_config.dart';
 import 'package:inno_bundle/models/dll_entry.dart';
+import 'package:inno_bundle/models/file_entry.dart';
 import 'package:inno_bundle/models/language.dart';
-import 'package:inno_bundle/models/vcredist_mode.dart';
 import 'package:inno_bundle/models/sign_tool.dart';
+import 'package:inno_bundle/models/vcredist_mode.dart';
 import 'package:inno_bundle/utils/cli_logger.dart';
 import 'package:inno_bundle/utils/constants.dart';
 import 'package:inno_bundle/utils/functions.dart';
-import 'package:path/path.dart' as p;
-import 'package:uuid/uuid.dart';
 
 /// A class representing the configuration for building a Windows installer using Inno Setup.
 class Config {
@@ -94,11 +96,15 @@ class Config {
 
   /// List of dlls to be included in the installer.
   final List<DllEntry> dlls;
+  
+  /// List of files to be included in the installer.
+  final List<FileEntry> files;
 
   /// Creates a [Config] instance with default values.
   const Config({
     required this.pubspecFile,
     required this.dlls,
+    required this.files,
     required this.buildArgs,
     required this.id,
     required this.pubspecName,
@@ -283,6 +289,18 @@ class Config {
         .whereType<DllEntry>()
         .toList(growable: false);
 
+    final files = ((inno['files'] ?? []) as List)
+        .map((d) {
+          if (d == null) return null;
+
+          final dllError = FileEntry.validateConfig(d);
+          if (dllError != null) CliLogger.exitError(dllError);
+
+          return FileEntry.fromJson(d);
+        })
+        .whereType<FileEntry>()
+        .toList(growable: false);
+
     return Config(
       pubspecFile: pubspecFile,
       buildArgs: cliConfig.buildArgs,
@@ -306,6 +324,7 @@ class Config {
       arch: arch,
       vcRedist: vcRedist,
       dlls: dlls,
+      files: files,
     );
   }
 

--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -310,6 +310,8 @@ class Config {
         .whereType<FileEntry>()
         .toList(growable: false);
 
+    final skipBuild = inno['skipBuild'] as bool? ?? false;
+
     return Config(
       pubspecFile: pubspecFile,
       buildArgs: cliConfig.buildArgs,
@@ -334,6 +336,7 @@ class Config {
       vcRedist: vcRedist,
       dlls: dlls,
       files: files,
+      skipBuild: skipBuild,
     );
   }
 

--- a/lib/models/dll_entry.dart
+++ b/lib/models/dll_entry.dart
@@ -27,8 +27,10 @@ library;
 
 import 'dart:io';
 
-import 'package:inno_bundle/utils/constants.dart';
 import 'package:path/path.dart' as p;
+
+import 'package:inno_bundle/models/file_raw_entry.dart';
+import 'package:inno_bundle/utils/constants.dart';
 
 /// Enum representing the source of the DLL.
 enum DllSource {
@@ -43,64 +45,23 @@ enum DllSource {
 }
 
 /// Class holding the DLL entry properties.
-class DllEntry {
-  /// The path to the DLL file.
-  final String path;
-
-  /// The name for the DLL. Defaults to the basename of the path.
-  final String name;
-
-  /// A flag indicating if the DLL is required. Defaults to true.
-  final bool required;
-
+class DllEntry extends FileRawEntry {
   /// An enum indicating the source of the DLL. Defaults to DllSource.project.
   final DllSource source;
 
-  DllEntry({
-    required this.path,
-    required this.name,
-    this.required = true,
+  const DllEntry({
+    required super.path,
+    required super.name,
+    super.required = true,
     this.source = DllSource.project,
   });
 
   static String? validateConfig(dynamic option) {
-    if (option == null) return null;
-    if (option is String) {
-      if (!option.toLowerCase().endsWith('.dll')) {
-        return "path in inno_bundle.dlls in pubspec.yaml must point to a DLL file, "
-            "got $option.";
-      }
-      return null;
-    }
-    if (option is Map<String, dynamic>) {
-      if (option['path'] == null) {
-        return "path field is missing from inno_bundle.dlls entry in pubspec.yaml, "
-            "it must be a string.";
-      }
-      final path = option['path'];
-      if (path is! String) {
-        return "path field in inno_bundle.dlls entry in pubspec.yaml must be a string.";
-      }
-      if (!path.toLowerCase().endsWith('.dll')) {
-        return "path in inno_bundle.dlls in pubspec.yaml must point to a DLL file, "
-            "got $path.";
-      }
-      if (option['name'] != null && option['name'] is! String) {
-        return "name field in inno_bundle.dlls entry in pubspec.yaml must be a string or null.";
-      }
-      if (option['required'] != null && option['required'] is! bool) {
-        return "required field in inno_bundle.dlls entry in pubspec.yaml must be a boolean or null.";
-      }
-      if (option['source'] != null &&
-          (option['source'] is! String ||
-              !DllSource.literalValues.contains(option['source']))) {
-        return "source field in inno_bundle.dlls entry in pubspec.yaml must be "
-            "one of ${DllSource.literalValues.join(', ')} or null.";
-      }
-      return null;
-    }
-
-    return "inno_bundle.dlls attribute is invalid in pubspec.yaml.";
+    return FileRawEntry.validateConfig(
+      option,
+      propertyName: 'dlls',
+      requiredExtension: 'dll',
+    );
   }
 
   factory DllEntry.fromJson(dynamic json) {
@@ -143,6 +104,7 @@ class DllEntry {
   }
 
   /// Get dll file absolute path.
+  @override
   String get absolutePath {
     if (p.isAbsolute(path)) return path;
     if (source == DllSource.project) {

--- a/lib/models/file_entry.dart
+++ b/lib/models/file_entry.dart
@@ -1,0 +1,36 @@
+import 'package:inno_bundle/models/file_raw_entry.dart';
+
+class FileEntry extends FileRawEntry {
+  final String? destinationDir;
+
+  const FileEntry({
+    this.destinationDir,
+    required super.path,
+    required super.name,
+    super.required = true,
+  });
+
+  static String? validateConfig(dynamic option) {
+    return FileRawEntry.validateConfig(
+      option,
+      propertyName: 'files',
+      requiredExtension: null,
+    );
+  }
+
+  factory FileEntry.fromJson(dynamic json) {
+    final e = FileRawEntry.fromJson(json);
+
+    String? destinationDir;
+    if (json is Map) {
+      destinationDir = json['destination'] as String?;
+    }
+
+    return FileEntry(
+      path: e.path,
+      name: e.name,
+      required: e.required,
+      destinationDir: destinationDir,
+    );
+  }
+}

--- a/lib/models/file_raw_entry.dart
+++ b/lib/models/file_raw_entry.dart
@@ -1,0 +1,92 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'package:inno_bundle/models/dll_entry.dart';
+
+/// Base Class holding the file entry properties.
+class FileRawEntry {
+  /// The path to the file.
+  final String path;
+
+  /// The name for the file. Defaults to the basename of the path.
+  final String name;
+
+  /// A flag indicating if the file is required. Defaults to true.
+  final bool required;
+
+  const FileRawEntry({
+    required this.path,
+    required this.name,
+    this.required = true,
+  });
+
+  /// Get file absolute path.
+  String get absolutePath {
+    if (p.isAbsolute(path)) return path;
+    return p.join(Directory.current.path, path);
+  }
+
+  static String? validateConfig(
+    dynamic option, {
+    required String propertyName,
+    required String? requiredExtension,
+  }) {
+    if (option == null) return null;
+    if (option is String) {
+      if (requiredExtension != null && !option.toLowerCase().endsWith('.$requiredExtension')) {
+        return "path in inno_bundle.$propertyName in pubspec.yaml must point to a $requiredExtension file, "
+            "got $option.";
+      }
+      return null;
+    }
+    if (option is Map<String, dynamic>) {
+      if (option['path'] == null) {
+        return "path field is missing from inno_bundle.$propertyName entry in pubspec.yaml, "
+            "it must be a string.";
+      }
+      final path = option['path'];
+      if (path is! String) {
+        return "path field in inno_bundle.$propertyName entry in pubspec.yaml must be a string.";
+      }
+      if (requiredExtension != null && !path.toLowerCase().endsWith('.$requiredExtension')) {
+        return "path in inno_bundle.$propertyName in pubspec.yaml must point to a $requiredExtension file, "
+            "got $path.";
+      }
+      if (option['name'] != null && option['name'] is! String) {
+        return "name field in inno_bundle.$propertyName entry in pubspec.yaml must be a string or null.";
+      }
+      if (option['required'] != null && option['required'] is! bool) {
+        return "required field in inno_bundle.$propertyName entry in pubspec.yaml must be a boolean or null.";
+      }
+      if (option['source'] != null && (option['source'] is! String || !DllSource.literalValues.contains(option['source']))) {
+        return "source field in inno_bundle.$propertyName entry in pubspec.yaml must be "
+            "one of ${DllSource.literalValues.join(', ')} or null.";
+      }
+      return null;
+    }
+
+    return "inno_bundle.$propertyName attribute is invalid in pubspec.yaml.";
+  }
+
+  factory FileRawEntry.fromJson(dynamic json) {
+    assert(json != null);
+    if (json is String) {
+      return DllEntry(
+        path: json,
+        name: p.basename(json),
+        required: true,
+        source: DllSource.project,
+      );
+    }
+    final path = json['path'] as String;
+    final name = json['name'] as String? ?? p.basename(path);
+    final required = json['required'] as bool? ?? true;
+
+    return FileRawEntry(
+      path: path,
+      name: name,
+      required: required,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inno_bundle
 description: CLI tool for automating Windows installer creation using Inno Setup.
 maintainer: Hocine Abdellatif Houari
-version: 0.9.0
+version: 0.10.0
 homepage: https://github.com/hahouari/inno_bundle
 
 environment:


### PR DESCRIPTION
Shorebird uses custom engine to build windows apps which can receive app updates as OTA patches. So we need to skip build if the custom engine build exe file available there. The user need to pass skipBuild as true if user want to skip flutter build command.