### PR TITLE
feat: Add optional Shorebird build tool support with CLI and YAML integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ dart run inno_bundle
 
 **Note:** This will generate the initial configuration if not present in your `pubspec.yaml`.
 
+### Use Shorebird for the app build (optional)
+
+To build using Shorebird instead of Flutter (enables code-push workflows):
+
+```sh
+dart run inno_bundle --build-tool shorebird
+```
+
+Pass extra Shorebird args if needed (example):
+
+```sh
+dart run inno_bundle --build-tool shorebird --shorebird-args "--artifact=exe"
+```
+
 # More Options and Examples
 
 You can find detailed documentation on customizing `inno_bundle`, including examples, on the [GitHub wiki pages](https://github.com/hahouari/inno_bundle/wiki).

--- a/README.md
+++ b/README.md
@@ -43,3 +43,20 @@ You can copy the [build.yaml](https://github.com/hahouari/flutter_inno_workflows
 # Reporting Issues
 
 If you encounter any issues <a href="https://github.com/hahouari/inno_bundle/issues" target="_blank">please report them here</a>.
+
+## Shorebird support (optional)
+
+By default, `inno_bundle` uses the Flutter CLI to build your app (`flutter build windows`). You can opt into Shorebird releases to enable code-push based workflows.
+
+- CLI flags:
+	- `--build-tool shorebird` to use Shorebird
+	- `--shorebird-args "--artifact=exe --staged"` to pass extra args to `shorebird release windows`
+- YAML config (`inno_bundle.yaml` or `pubspec.yaml` under `inno_bundle`):
+	- `build_tool: shorebird`
+
+Commands executed:
+
+- Shorebird: `shorebird release windows [--debug|--profile] <shorebird-args>`
+- Flutter (default): `flutter build windows ./lib/main.dart --<mode> --obfuscate --split-debug-info=build/obfuscate --build-name <x> --build-number <y> <build-args>`
+
+This is non-breaking; existing usage requires no changes.

--- a/bin/inno_bundle.dart
+++ b/bin/inno_bundle.dart
@@ -69,6 +69,14 @@ void main(List<String> arguments) async {
           'and only if maintainer field is not present in config file',
     )
     ..addOption("build-args", help: "Append args to \"flutter build ...\"")
+    ..addOption("shorebird-args",
+        help: "Append args to \"shorebird release windows ...\"")
+    ..addOption(
+      "build-tool",
+      help: "Select build tool: flutter (default) or shorebird",
+      allowed: ["flutter", "shorebird"],
+      defaultsTo: "flutter",
+    )
     ..addOption("app-version", help: "Override app version")
     ..addOption("sign-tool-name", help: "Override sign tool name")
     ..addOption("sign-tool-command", help: "Override sign tool command")

--- a/example/README.md
+++ b/example/README.md
@@ -1,3 +1,13 @@
 # Inno bundle examples
 
 - [demo_app](https://github.com/hahouari/inno_bundle/tree/dev/example/demo_app)
+
+## Using Shorebird (optional)
+
+You can opt into Shorebird releases for Windows by passing:
+
+```
+dart run inno_bundle --build-tool shorebird --shorebird-args "--artifact=exe"
+```
+
+Or set `build_tool: shorebird` under the `inno_bundle:` section of your config.

--- a/lib/builders/app_builder.dart
+++ b/lib/builders/app_builder.dart
@@ -10,6 +10,8 @@ library;
 import 'dart:io';
 
 import 'package:inno_bundle/models/config.dart';
+import 'package:inno_bundle/models/build_tool.dart';
+import 'package:inno_bundle/models/build_type.dart';
 import 'package:inno_bundle/utils/constants.dart';
 import 'package:path/path.dart' as p;
 import 'package:inno_bundle/utils/cli_logger.dart';
@@ -51,9 +53,35 @@ class AppBuilder {
       }
     }
 
-    final process = await Process.start(
-      "flutter",
-      [
+    // Choose build tool
+    final bool useShorebird = config.buildTool == BuildTool.shorebird;
+
+    Process process;
+    if (useShorebird) {
+      // Build using Shorebird: shorebird release windows ...
+      final shorebirdArgs = <String>[
+        'release',
+        'windows',
+        if (config.type != BuildType.release) '--${config.type.name}',
+        // users will typically set version via pubspec; shorebird uses app_version internally for releases if needed
+      ];
+
+      // Append any user-specified args string as a single token to match existing style
+      final extra = config.shorebirdArgs;
+      if (extra != null && extra.isNotEmpty) {
+        shorebirdArgs.add(extra);
+      }
+
+      process = await Process.start(
+        'shorebird',
+        shorebirdArgs,
+        runInShell: true,
+        workingDirectory: Directory.current.path,
+        mode: ProcessStartMode.inheritStdio,
+      );
+    } else {
+      // Default: Build using Flutter
+      final flutterArgs = <String>[
         'build',
         'windows',
         './lib/main.dart',
@@ -64,12 +92,21 @@ class AppBuilder {
         buildName,
         '--build-number',
         buildNumber,
-        config.buildArgs ?? "",
-      ],
-      runInShell: true,
-      workingDirectory: Directory.current.path,
-      mode: ProcessStartMode.inheritStdio,
-    );
+      ];
+
+      final extra = config.buildArgs;
+      if (extra != null && extra.isNotEmpty) {
+        flutterArgs.add(extra);
+      }
+
+      process = await Process.start(
+        'flutter',
+        flutterArgs,
+        runInShell: true,
+        workingDirectory: Directory.current.path,
+        mode: ProcessStartMode.inheritStdio,
+      );
+    }
 
     final exitCode = await process.exitCode;
 

--- a/lib/models/build_tool.dart
+++ b/lib/models/build_tool.dart
@@ -1,0 +1,34 @@
+/// Represents the tool used to build the Windows application.
+library;
+
+import 'package:args/args.dart';
+
+/// Supported build tools.
+enum BuildTool {
+  /// Use Flutter CLI to build: `flutter build windows`.
+  flutter,
+
+  /// Use Shorebird CLI to build/release: `shorebird release windows`.
+  shorebird;
+
+  /// Parse from CLI args (expects an option named `build-tool`).
+  static BuildTool fromArgs(ArgResults args) {
+    final value = args['build-tool'] as String?;
+    return fromOption(value);
+  }
+
+  /// Parse from a string option (e.g., from YAML), defaults to [BuildTool.flutter].
+  static BuildTool fromOption(Object? option) {
+    final s = option?.toString().toLowerCase().trim();
+    switch (s) {
+      case 'shorebird':
+        return BuildTool.shorebird;
+      case 'flutter':
+      case null:
+      case '':
+        return BuildTool.flutter;
+      default:
+        return BuildTool.flutter;
+    }
+  }
+}

--- a/lib/models/cli_config.dart
+++ b/lib/models/cli_config.dart
@@ -4,6 +4,7 @@ library;
 
 import 'package:args/args.dart';
 import 'package:inno_bundle/models/build_type.dart';
+import 'package:inno_bundle/models/build_tool.dart';
 
 /// A class representing the configuration for the command-line interface.
 class CliConfig {
@@ -33,6 +34,15 @@ class CliConfig {
   /// Arguments to be passed to flutter build.
   final String? buildArgs;
 
+  /// Optional additional args to be passed to shorebird release.
+  final String? shorebirdArgs;
+
+  /// Selected tool to build the Windows app.
+  final BuildTool buildTool;
+
+  /// Whether `--build-tool` was explicitly provided on the CLI.
+  final bool hasBuildToolArg;
+
   /// Override app version.
   final String? appVersion;
 
@@ -55,10 +65,13 @@ class CliConfig {
     this.generatePublisher = true,
     this.appIdNamespace,
     this.buildArgs,
+    this.shorebirdArgs,
     this.appVersion,
     this.signToolName,
     this.signToolCommand,
     this.signToolParams,
+    this.buildTool = BuildTool.flutter,
+    this.hasBuildToolArg = false,
   });
 
   /// Creates a [CliConfig] instance from command-line arguments using [ArgResults].
@@ -72,10 +85,13 @@ class CliConfig {
       appIdNamespace: args['app-id-ns'],
       generatePublisher: args['gen-publisher'],
       buildArgs: args['build-args'],
+      shorebirdArgs: args['shorebird-args'],
       appVersion: args['app-version'],
       signToolName: args['sign-tool-name'],
       signToolCommand: args['sign-tool-command'],
       signToolParams: args['sign-tool-params'],
+      buildTool: BuildTool.fromArgs(args),
+      hasBuildToolArg: args.wasParsed('build-tool'),
     );
   }
 }

--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -17,6 +17,7 @@ import 'dart:io';
 import 'package:inno_bundle/models/admin_mode.dart';
 import 'package:inno_bundle/models/build_arch.dart';
 import 'package:inno_bundle/models/build_type.dart';
+import 'package:inno_bundle/models/build_tool.dart';
 import 'package:inno_bundle/models/cli_config.dart';
 import 'package:inno_bundle/models/file_entry.dart';
 import 'package:inno_bundle/models/language.dart';
@@ -93,6 +94,12 @@ class Config {
   /// Arguments to be passed to flutter build.
   final String? buildArgs;
 
+  /// Arguments to be passed to shorebird release.
+  final String? shorebirdArgs;
+
+  /// The tool to use for building the app (flutter or shorebird).
+  final BuildTool buildTool;
+
   /// The mode for handling the Visual C++ Redistributable.
   final VcRedistMode vcRedist;
 
@@ -105,6 +112,8 @@ class Config {
     required this.configFile,
     required this.files,
     required this.buildArgs,
+    required this.shorebirdArgs,
+    required this.buildTool,
     required this.id,
     required this.pubspecName,
     required this.name,
@@ -311,6 +320,12 @@ class Config {
       pubspecFile: pubspecFile,
       configFile: configFile,
       buildArgs: cliConfig.buildArgs,
+      shorebirdArgs:
+          cliConfig.shorebirdArgs ?? (inno['shorebird_args'] as String?),
+      buildTool: cliConfig.hasBuildToolArg
+          ? cliConfig.buildTool
+          : BuildTool.fromOption(
+              inno['build_tool'] ?? cliConfig.buildTool.name),
       id: id,
       pubspecName: pubspecName,
       name: name,

--- a/test/inno_bundle_test.dart
+++ b/test/inno_bundle_test.dart
@@ -1,1 +1,19 @@
-void main() {}
+import 'package:args/args.dart';
+import 'package:inno_bundle/models/build_tool.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BuildTool parsing', () {
+    test('defaults to flutter when not provided', () {
+      final parser = ArgParser()..addOption('build-tool');
+      final args = parser.parse([]);
+      expect(BuildTool.fromArgs(args), BuildTool.flutter);
+    });
+
+    test('parses shorebird', () {
+      final parser = ArgParser()..addOption('build-tool');
+      final args = parser.parse(['--build-tool', 'shorebird']);
+      expect(BuildTool.fromArgs(args), BuildTool.shorebird);
+    });
+  });
+}


### PR DESCRIPTION
## Overview
This PR introduces **optional support for the Shorebird build tool** in the inno_bundle package, enabling users to build Windows apps using `shorebird release windows` as an alternative to the traditional `flutter build windows`. This supports Shorebird workflows for initial build.

## Features
- New CLI flags: `--build-tool` (default: flutter) and `--shorebird-args`
- New YAML config: `build_tool: shorebird` and `shorebird_args: ...`
- Documentation and usage added to README.md and example README
- AppBuilder delegates to Shorebird or Flutter build logic based on config/CLI
- Shorebird build tool support is fully optional—omit the flag or config to continue using the regular Flutter build and inno_bundle workflow.
- Parsing and unit tests added for new configuration options

## Usage Example

### CLI
```sh
dart run inno_bundle --build-tool shorebird --shorebird-args="--artifact=exe --staged"
```
### YAML
```yaml
inno_bundle:
  build_tool: shorebird
  shorebird_args: "--artifact=exe"
```

## Motivation
- Adds support for a tool I use in my Flutter projects.

## Notes
- No breaking changes. 
---

Thank you for reviewing this PR! Feedback, suggestions, and code review are welcome.