### PR TITLE
feat: file extensions associations ("open with" in explorer menu)

### DIFF
--- a/lib/builders/script_builder.dart
+++ b/lib/builders/script_builder.dart
@@ -20,11 +20,11 @@ library;
 
 import 'dart:io';
 
-import 'package:inno_bundle/models/file_entry.dart';
 import 'package:path/path.dart' as p;
 
 import 'package:inno_bundle/models/admin_mode.dart';
 import 'package:inno_bundle/models/config.dart';
+import 'package:inno_bundle/models/file_entry.dart';
 import 'package:inno_bundle/models/vcredist_mode.dart';
 import 'package:inno_bundle/utils/cli_logger.dart';
 import 'package:inno_bundle/utils/constants.dart';
@@ -86,6 +86,7 @@ ArchitecturesInstallIn64BitMode=${config.arch.value}
 DisableDirPage=auto
 DisableProgramGroupPage=auto
 ${config.signTool != null ? config.signTool?.toInnoCode() : ""}
+${config.fileExtensionsAssociations.isNotEmpty || config.fileExtensionsAssociationsExclude.isNotEmpty ? "ChangesAssociations=yes" : ""}
 \n''';
   }
 
@@ -265,6 +266,62 @@ end;
 \n''';
   }
 
+  String _fileExtensionsAssociationsText() {
+    if (config.fileExtensionsAssociations.isEmpty && config.fileExtensionsAssociationsExclude.isEmpty) return '';
+    final name = config.name;
+
+    String extensionCommandBuilder(String ext, String Function(String extWithDot, String extWithoutDot, String regLocationName) fn) {
+      String extWithDot;
+      String extWithoutDot;
+      if (ext.startsWith('.')) {
+        extWithDot = ext;
+        extWithoutDot = ext.substring(1);
+      } else {
+        extWithDot = '.$ext';
+        extWithoutDot = ext;
+      }
+      final regLocationName = '$name$extWithDot';
+      return fn(extWithDot, extWithoutDot, regLocationName);
+    }
+
+    final createCapabilityKeyCommand = '''
+Root: HKA; Subkey: "Software\\${name}"; Flags: uninsdeletekeyifempty
+Root: HKA; Subkey: "Software\\${name}\\Capability"; ValueType: string; ValueName: "ApplicationName"; ValueData: "${name}"; Flags: uninsdeletevalue
+Root: HKA; Subkey: "Software\\${name}\\Capability"; ValueType: string; ValueName: "ApplicationDescription"; ValueData: "${config.description}"; Flags: uninsdeletevalue
+Root: HKA; Subkey: "Software\\RegisteredApplications"; ValueType: string; ValueName: "${name}"; ValueData: "Software\\${name}\\Capability"; Flags: uninsdeletevalue
+''';
+
+    final removeOldExtensionsCommands = config.fileExtensionsAssociationsExclude.map(
+      (ext) {
+        return extensionCommandBuilder(ext, (extWithDot, extWithoutDot, regLocationName) {
+          return 'Root: HKA; Subkey: "Software\\Classes\\$regLocationName"; Flags: deletekey';
+        });
+      },
+    ).join('\n');
+    final allExtensionsCommands = config.fileExtensionsAssociations.map(
+      (ext) {
+        return extensionCommandBuilder(ext, (extWithDot, extWithoutDot, regLocationName) {
+          return '''
+Root: HKA; Subkey: "Software\\${name}\\Capability\\FileAssociations"; ValueType: string; ValueName: "$extWithDot"; ValueData: "$regLocationName"; Flags: uninsdeletevalue
+Root: HKA; Subkey: "Software\\Classes\\$extWithDot\\OpenWithProgids"; ValueType: string; ValueName: "$regLocationName"; ValueData: ""; Flags: uninsdeletevalue
+Root: HKA; Subkey: "Software\\Classes\\$regLocationName"; ValueType: string; ValueName: ""; ValueData: "${extWithoutDot.toUpperCase()} File"; Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\\Classes\\$regLocationName\\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\\${config.exePubspecName},0"
+Root: HKA; Subkey: "Software\\Classes\\$regLocationName\\shell\\open\\command"; ValueType: string; ValueName: ""; ValueData: """{app}\\${config.exePubspecName}"" ""%1"""
+Root: HKA; Subkey: "Software\\Classes\\Applications\\${name}\\SupportedTypes"; ValueType: string; ValueName: "$extWithDot"; ValueData: ""
+''';
+        });
+      },
+    ).join('\n');
+
+    return '''
+[Registry]
+
+$createCapabilityKeyCommand
+$removeOldExtensionsCommands
+$allExtensionsCommands
+\n''';
+  }
+
   /// Generates the ISS script file and returns its path.
   Future<File> build() async {
     CliLogger.info("Generating ISS script...");
@@ -274,6 +331,7 @@ end;
         _languages() +
         _tasks() +
         _files() +
+        _fileExtensionsAssociationsText() +
         _icons() +
         _run() +
         _downloadVcRedist();

--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -14,10 +14,13 @@ library;
 
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+import 'package:uuid/uuid.dart';
+
 import 'package:inno_bundle/models/admin_mode.dart';
 import 'package:inno_bundle/models/build_arch.dart';
-import 'package:inno_bundle/models/build_type.dart';
 import 'package:inno_bundle/models/build_tool.dart';
+import 'package:inno_bundle/models/build_type.dart';
 import 'package:inno_bundle/models/cli_config.dart';
 import 'package:inno_bundle/models/file_entry.dart';
 import 'package:inno_bundle/models/language.dart';
@@ -26,8 +29,6 @@ import 'package:inno_bundle/models/vcredist_mode.dart';
 import 'package:inno_bundle/utils/cli_logger.dart';
 import 'package:inno_bundle/utils/constants.dart';
 import 'package:inno_bundle/utils/functions.dart';
-import 'package:path/path.dart' as p;
-import 'package:uuid/uuid.dart';
 
 /// A class representing the configuration for building a Windows installer using Inno Setup.
 class Config {
@@ -106,11 +107,26 @@ class Config {
   /// List of files to be included in the installer.
   final List<FileEntry> files;
 
+  /// List of file extensions to **assign for/associate with** the app (ie. "Open with" in file explorer menu).
+  /// 
+  /// WARNING: Do NOT remove extensions after they were added (and app was installed on user device), 
+  /// Use [fileExtensionsAssociationsExclude] instead to properly remove file associations without
+  /// the need to uninstall the app.
+  final List<String> fileExtensionsAssociations;
+
+  /// List of file extensions to **remove** in case they were added in [fileExtensionsAssociations] before.
+  /// 
+  /// Normally, the file associations will get removed on app uninstall, but this can be used to dynamically
+  /// remove them with a normal update.
+  final List<String> fileExtensionsAssociationsExclude;
+
   /// Creates a [Config] instance with default values.
   const Config({
     required this.pubspecFile,
     required this.configFile,
     required this.files,
+    required this.fileExtensionsAssociations,
+    required this.fileExtensionsAssociationsExclude,
     required this.buildArgs,
     required this.shorebirdArgs,
     required this.buildTool,
@@ -316,6 +332,9 @@ class Config {
         .whereType<FileEntry>()
         .toList(growable: false);
 
+    final fileExtensionsAssociations = (inno['file_extensions_associations'] as List?)?.cast<String>() ?? <String>[];
+    final fileExtensionsAssociationsExclude = (inno['file_extensions_associations_exclude'] as List?)?.cast<String>() ?? <String>[];
+
     return Config(
       pubspecFile: pubspecFile,
       configFile: configFile,
@@ -346,6 +365,8 @@ class Config {
       arch: arch,
       vcRedist: vcRedist,
       files: files,
+      fileExtensionsAssociations: fileExtensionsAssociations,
+      fileExtensionsAssociationsExclude: fileExtensionsAssociationsExclude,
     );
   }
 

--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -332,8 +332,19 @@ class Config {
         .whereType<FileEntry>()
         .toList(growable: false);
 
-    final fileExtensionsAssociations = (inno['file_extensions_associations'] as List?)?.cast<String>() ?? <String>[];
-    final fileExtensionsAssociationsExclude = (inno['file_extensions_associations_exclude'] as List?)?.cast<String>() ?? <String>[];
+    final hasAnyCharRegex = RegExp(r'[^\s]');
+    List<String> _ensureListSplit(List? original) {
+      final list = <String>[];
+      if (original == null) return list;
+      for (final extensionPart in original) {
+        final extensions = (extensionPart as String).split(',');
+        list.addAll(extensions.where(hasAnyCharRegex.hasMatch));
+      }
+      return list;
+    }
+
+    final fileExtensionsAssociations = _ensureListSplit(inno['file_extensions_associations'] as List?);
+    final fileExtensionsAssociationsExclude = _ensureListSplit(inno['file_extensions_associations_exclude'] as List?);
 
     return Config(
       pubspecFile: pubspecFile,


### PR DESCRIPTION
an option to provide extensions to "associate" with the app.

for example, adding ".mp4" to `file_extensions_associations` will tell windows that app can open mp4 files, hence will appear in "open with" menu.

one downside is that added extensions can be removed automatically only on app uninstall, otherwise it needs to be removed manually, which is the purpose of `file_extensions_associations_exclude`.

### Docs
```dart

  /// List of file extensions to **assign for/associate with** the app (ie. "Open with" in file explorer menu).
  /// 
  /// WARNING: Do NOT remove extensions after they were added (and app was installed on user device), 
  /// Use [fileExtensionsAssociationsExclude] instead to properly remove file associations without
  /// the need to uninstall the app.
  final List<String> fileExtensionsAssociations;

  /// List of file extensions to **remove** in case they were added in [fileExtensionsAssociations] before.
  /// 
  /// Normally, the file associations will get removed on app uninstall, but this can be used to dynamically
  /// remove them with a normal update
  final List<String> fileExtensionsAssociationsExclude;
```

### Configuration Options
```yaml
  file_extensions_associations:
    - mp3
    - m4a
  file_extensions_associations_exclude:
    - flac # we added flac before, so it needs to stay here to be removed properly on app update
```

### Extra

#### alternatives for `file_extensions_associations_exclude`:
ultimately, the best solution for this case is to remove them in [Code] section using similar code like below, however as i tried it didn't work as expected, not sure where the issue is since im not an expert in this
```iss
procedure DeleteAllAssociations();
var
  regKey, regLocationName: String;
  values: TArrayOfString;
  i: Integer;
begin
  regKey := 'Software\\' + '${config.name}' + '\\Capability\\FileAssociations';

  if not RegKeyExists(HKA, regKey) then
    exit;

  if not RegGetValueNames(HKA, regKey, values) then
    exit;

  for i := 0 to GetArrayLength(values) - 1 do begin
    regLocationName := '${config.name}' + values[i];
    if not RegQueryStringValue(HKA, regKey, values[i], regLocationName) then
      continue;
    RegDeleteValue(HKA, regKey, values[i]);
    RegDeleteValue(HKA, 'Software\\Classes\\' + values[i] + '\\OpenWithProgids', regLocationName);
    RegDeleteKeyIncludingSubkeys(HKA, 'Software\\Classes\\' + regLocationName);
    RegDeleteValue(HKA, 'Software\\Classes\\Applications\\' + '${config.name}' + '\\SupportedTypes', values[i]);
  end;
  RegDeleteKeyIfEmpty(HKA, regKey);
end;
```

as always thanks for the awesome work on this package ! ❤️